### PR TITLE
(#133) Fixed the `docker-compose up installer`.

### DIFF
--- a/containers/installer/Dockerfile
+++ b/containers/installer/Dockerfile
@@ -1,5 +1,9 @@
 FROM minds/php:latest
 
+# Install the necessary package dependencies.
+RUN apk add git npm
+
 COPY containers/installer/install.sh install.sh
 
 ENTRYPOINT [ "sh", "./install.sh" ]
+


### PR DESCRIPTION
**The Problem** was that the inherited docker image no longer contains
the packages for git and npm.

**The Solution** was to edit the relevant Dockerfile and install them via apk.

Fixes Minds/minds#133