### PR TITLE
Public relay name change

### DIFF
--- a/Core/Nostr/ThirdPartyRelays.php
+++ b/Core/Nostr/ThirdPartyRelays.php
@@ -74,7 +74,7 @@ class ThirdPartyRelays
         }
         $relays = $this->config->get('nostr')['relays'] ?? [
                 'wss://nostr-relay.untethr.me',
-                'wss://nostr.bitcoiner.social',
+                'wss://offchain.pub',
                 'wss://nostr-relay.wlvs.space',
                 'wss://nostr-pub.wellorder.net'
             ];

--- a/settings.example.php
+++ b/settings.example.php
@@ -896,7 +896,7 @@ $CONFIG->set('nostr', [
     'domain' => 'minds.io',
     'relays' => [
         'wss://nostr-relay.untethr.me',
-        'wss://nostr.bitcoiner.social',
+        'wss://offchain.pub',
         'wss://nostr-relay.wlvs.space',
         'wss://nostr-pub.wellorder.net'
     ]


### PR DESCRIPTION
nostr.bitcoiner.social -> offchain.pub

note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74

> Before I deployed the new pay-to-relay server, I ran a public relay under a "nostr" subdomain. I've since renamed my public relay to wss://offchain.pub. Much cooler name. Better represents how nostr isn't something this domain handles on the side, it's the primary purpose. Raison d'etre.
> 
> Both offchain.pub and the "nostr" subdomain will work concurrently for awhile, pointing to the same public relay server. But I'll eventually deprecate the "nostr" subdomain and redirect requests to the new offchain.pub name.